### PR TITLE
Ensure SSH keys are setup correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,12 @@ jobs:
           name: Installing rsync
           command: apt-get update && apt-get install -y rsync
 
+      - add_ssh_keys
+
+      - run:
+          name: Scan server keys
+          command: touch ~/.ssh/known_hosts && ssh-keyscan www.verynicecode.biz >> ~/.ssh/known_hosts
+
       - checkout
 
       - restore_cache:


### PR DESCRIPTION
In order for this automatic deployment to work, I had to manually add a step to add the private key that I had setup for this and then also scan the server to get those public keys in my known hosts so that `rsync` didn't ask for permission. This was a lot of faffing so please don't forget how this works!