### PR TITLE
Set Gemfile platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-19
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   middleman


### PR DESCRIPTION
I'm seeing errors like this:

```
bundle install
  /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle config --local path /home/runner/work/vnc-site/vnc-site/vendor/bundle
  /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle config --local deployment true
  Cache key: setup-ruby-bundler-cache-v3-ubuntu-20.04-ruby-3.0.1-Gemfile.lock-31abd0f16fd921ff931c34aef94965f5ffaf99c460778b3f882f683324d3c953
  /opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle install --jobs 4
  Your bundle only supports platforms ["x86_64-darwin-19", "x86_64-darwin-20"] but
  your local platform is x86_64-linux. Add the current platform to the lockfile
  with `bundle lock --add-platform x86_64-linux` and try again.
  Took   1.17 seconds
Error: The process '/opt/hostedtoolcache/Ruby/3.0.1/x64/bin/bundle' failed with exit code 16
```

When GitHub Actions goes to boot up but I don't see this on projects where the Gemfile.lock has a looser PLATFORM setting of simply `ruby` so I'm attempting to see if that will fix this.